### PR TITLE
Changed the extension folder to 'aem-cf-console-admin-1' for consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aem-cf-admin-ui-ext-tpl",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "main": "src/index.js",
   "description": "Extensibility Template for AEM Content Fragment Console",
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ class MainGenerator extends Generator {
   
   initializing () {
     // all paths are relative to root
-    this.extFolder = 'src/aem/cf-console-admin-1'
+    this.extFolder = 'src/aem-cf-console-admin-1'
     this.actionFolder = path.join(this.extFolder, 'actions')
     
     this.webSrcFolder = path.join(this.extFolder, 'web-src')

--- a/src/templates/web/index.html
+++ b/src/templates/web/index.html
@@ -7,7 +7,7 @@
       <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
       <meta name="theme-color" content="#333333">
       <meta http-equiv="X-UA-Compatible" content="ie=edge">
-      <title>DEVX2049</title>
+      <title><%- extensionManifest.name %></title>
     </head>
     <body>
       <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed the extension folder to 'aem-cf-console-admin-1' for consistency.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To make the folder naming consistent with `dx-excshell-1`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployment to staging AEM instance via ext parameter.
Deployment to production AEM instance via ext parameter.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
