### PR TITLE
Add units tests and docs URL for configuring the demo application

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,8 +5,7 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: [],
   testPathIgnorePatterns: [
-    "<rootDir>/node_modules/",
-    "<rootDir>/src/templates/"
+    "<rootDir>/node_modules/"
   ],
   coverageThreshold: {
     global: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,11 +2,11 @@ module.exports = {
   testEnvironment: 'node',
   verbose: true,
   setupFilesAfterEnv: ['./test/jest.setup.js'],
-  collectCoverage: false,
-  collectCoverageFrom: [
-    'src/**/*.js'
-  ],
+  collectCoverage: true,
+  collectCoverageFrom: [],
   testPathIgnorePatterns: [
+    "<rootDir>/node_modules/",
+    "<rootDir>/src/templates/"
   ],
   coverageThreshold: {
     global: {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@adobe/aem-cf-admin-ui-ext-tpl",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "main": "src/index.js",
-  "description": "Extensibility Template for AEM Content Fragment Admin Console",
+  "description": "Extensibility template for AEM Content Fragment Admin Console",
   "engines": {
     "node": "^14"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@adobe/aem-cf-admin-ui-ext-tpl",
   "version": "1.0.0-beta.9",
   "main": "src/index.js",
-  "description": "Extensibility Template for AEM Content Fragment Console",
+  "description": "Extensibility Template for AEM Content Fragment Admin Console",
   "engines": {
     "node": "^14"
   },
@@ -25,9 +25,22 @@
     "@babel/plugin-transform-react-jsx": "^7.8.3",
     "@babel/polyfill": "^7.8.7",
     "@babel/preset-env": "^7.8.7",
+    "@types/jest": "^28.1.8",
     "jest": "^27",
     "stdout-stderr": "^0.1.13",
-    "yeoman-test": "^6.3.0"
+    "yeoman-test": "^6.3.0",
+    "eol": "^0.9.1",
+    "eslint": "^7.1.0",
+    "eslint-config-standard": "^14.1.0",
+    "eslint-plugin-import": "^2.19.1",
+    "eslint-plugin-jest": "^23.1.1",
+    "eslint-plugin-node": "^11.0.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^4.0.1",
+    "js-yaml": "^4.1.0",
+    "yeoman-assert": "^3.1.1",
+    "yeoman-environment": "^3.2.0",
+    "lodash.clonedeep": "^4.5.0"
   },
   "peerDependencies": {
     "@adobe/aio-cli-plugin-app-templates": "^1.0.0"

--- a/src/generator-add-action-cf-admin.js
+++ b/src/generator-add-action-cf-admin.js
@@ -13,7 +13,7 @@ const path = require('path')
 const { constants, ActionGenerator, commonTemplates } = require('@adobe/generator-app-common-lib')
 // const { commonDependencyVersions } = constants
 
-class CFAdminUIActionGenerator extends ActionGenerator {
+class CFAdminActionGenerator extends ActionGenerator {
   constructor (args, opts) {
     super(args, opts)
     this.props = {
@@ -87,4 +87,4 @@ const { Core } = require('@adobe/aio-sdk')`,
   }
 }
 
-module.exports = CFAdminUIActionGenerator
+module.exports = CFAdminActionGenerator

--- a/src/generator-add-web-assets-cf-admin.js
+++ b/src/generator-add-web-assets-cf-admin.js
@@ -15,7 +15,7 @@ const Generator = require('yeoman-generator')
 const { utils, constants } = require('@adobe/generator-app-common-lib')
 const { commonDependencyVersions } = constants
 
-class CFAdminUIGenerator extends Generator {
+class CFAdminWebAssetsGenerator extends Generator {
   constructor (args, opts) {
     super(args, opts)
     // required
@@ -64,7 +64,7 @@ class CFAdminUIGenerator extends Generator {
       '@adobe/aio-sdk': commonDependencyVersions['@adobe/aio-sdk'],
       '@adobe/exc-app': '^0.2.21',
       '@adobe/react-spectrum': '^3.4.0',
-      '@adobe/uix-guest': '^0.5.3',
+      '@adobe/uix-guest': '^0.6.3',
       '@react-spectrum/list': '^3.0.0-rc.0',
       '@spectrum-icons/workflow': '^3.2.0',
       'core-js': '^3.6.4',
@@ -153,4 +153,4 @@ class CFAdminUIGenerator extends Generator {
   }
 }
 
-module.exports = CFAdminUIGenerator
+module.exports = CFAdminWebAssetsGenerator

--- a/src/generator-add-web-assets-cf-admin.js
+++ b/src/generator-add-web-assets-cf-admin.js
@@ -64,7 +64,7 @@ class CFAdminWebAssetsGenerator extends Generator {
       '@adobe/aio-sdk': commonDependencyVersions['@adobe/aio-sdk'],
       '@adobe/exc-app': '^0.2.21',
       '@adobe/react-spectrum': '^3.4.0',
-      '@adobe/uix-guest': '^0.6.3',
+      '@adobe/uix-guest': '^0.6.4',
       '@react-spectrum/list': '^3.0.0-rc.0',
       '@spectrum-icons/workflow': '^3.2.0',
       'core-js': '^3.6.4',

--- a/src/index.js
+++ b/src/index.js
@@ -13,13 +13,14 @@ const Generator = require('yeoman-generator')
 const path = require('path')
 const upath = require('upath')
 const fs = require('fs-extra')
+const chalk = require('chalk')
 
 const CFAdminActionGenerator = require('./generator-add-action-cf-admin')
 const CFAdminWebAssetsGenerator = require('./generator-add-web-assets-cf-admin')
 
 const {constants, utils} = require('@adobe/generator-app-common-lib')
 const { runtimeManifestKey } = constants
-const { briefOverviews, promptTopLevelFields, promptMainMenu } = require('./prompts')
+const { briefOverviews, promptTopLevelFields, promptMainMenu, promptDocs } = require('./prompts')
 const { readManifest, writeManifest } = require('./utils')
 
 const EXTENSION_MANIFEST_PATH = path.join(process.cwd(), 'extension-manifest.json')
@@ -52,7 +53,7 @@ class MainGenerator extends Generator {
     this.extConfigPath = path.join(this.extFolder, 'ext.config.yaml')
     this.configName = 'aem/cf-console-admin/1'
 
-    if (!this.option('is-test')) {
+    if (!this.options['is-test']) {
       this.extensionManifest = readManifest(EXTENSION_MANIFEST_PATH)
     } else {
       this.extensionManifest = this.options['extension-manifest']
@@ -60,7 +61,7 @@ class MainGenerator extends Generator {
   }
 
   async prompting () {
-    if (!this.option('is-test')) {
+    if (!this.options['is-test']) {
       this.log(briefOverviews['templateInfo'])
       await promptTopLevelFields(this.extensionManifest)
         .then(() => promptMainMenu(this.extensionManifest))
@@ -144,10 +145,15 @@ class MainGenerator extends Generator {
   }
 
   async end () {
-    this.log('\nSample code files have been generated.\n')
-    this.log('Next steps:')
-    this.log('1) Populate your local environment variables in the ".env" file')
-    this.log('2) You can use `aio app run` or `aio app deploy` to see the sample code files in action')
+    this.log(chalk.bold('\nSample code files have been generated.\n'))
+    this.log(chalk.bold('Next Steps:'))
+    this.log(chalk.bold('-----------'))
+    this.log(chalk.bold('1) Populate your local environment variables in the ".env" file'))
+    this.log(chalk.bold('2) You can use `aio app run` or `aio app deploy` to see the sample code files in action'))
+    if (this.extensionManifest.templateFolder) {
+      this.log(chalk.bold('3) Please refer to the link below for configuring the demo application:'))
+      this.log(chalk.blue(chalk.bold(`   -> ${promptDocs['configureSlackDoc']}`)))
+    }
     this.log('\n')
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -148,8 +148,8 @@ class MainGenerator extends Generator {
     this.log(chalk.bold('\nSample code files have been generated.\n'))
     this.log(chalk.bold('Next Steps:'))
     this.log(chalk.bold('-----------'))
-    this.log(chalk.bold('1) Populate your local environment variables in the ".env" file'))
-    this.log(chalk.bold('2) You can use `aio app run` or `aio app deploy` to see the sample code files in action'))
+    this.log(chalk.bold('1) Populate your local environment variables in the ".env" file.'))
+    this.log(chalk.bold('2) You can use `aio app run` or `aio app deploy` to see the sample code files in action.'))
     if (this.extensionManifest.templateFolder) {
       this.log(chalk.bold('3) Please refer to the link below for configuring the demo application:'))
       this.log(chalk.blue(chalk.bold(`   -> ${promptDocs['configureSlackDoc']}`)))

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -29,7 +29,8 @@ const briefOverviews = {
 }
 
 const promptDocs = {
-  mainDoc: "https://developer.adobe.com/uix/docs/"
+  mainDoc: "https://developer.adobe.com/uix/docs/",
+  configureSlackDoc: "https://developer.adobe.com/uix/docs/services/aem-cf-console-admin/code-generation/#configure-demo-application"
 }
 
 // Top Level prompts
@@ -294,7 +295,8 @@ const promptGuideMenu = (manifest) => {
 
 // Helper prompts for Guide Menu
 const helpPrompts = () => {
-  console.log(chalk.blue(chalk.bold(`Please refer to:\n  -> ${promptDocs['mainDoc']}`)) + '\n')
+  console.log('  Please refer to:')
+  console.log(chalk.blue(chalk.bold(`  -> ${promptDocs['mainDoc']}`)) + '\n')
 }
 
 const dummyPrompt = () => {
@@ -304,5 +306,6 @@ const dummyPrompt = () => {
 module.exports = {
   briefOverviews,
   promptTopLevelFields,
-  promptMainMenu
+  promptMainMenu,
+  promptDocs
 }

--- a/src/templates/_shared/stub-app.ejs
+++ b/src/templates/_shared/stub-app.ejs
@@ -12,9 +12,9 @@ import ExtensionRegistration from "./ExtensionRegistration"
 <% const actionBarButtons = extensionManifest.actionBarButtons || [] -%>
 <% const headerMenuButtons = extensionManifest.headerMenuButtons || [] -%>
 <% const allCustomButtons = actionBarButtons.concat(headerMenuButtons) -%>
-  <% allCustomButtons.forEach((button) => { -%>
-    <% if (button.needsModal) { -%>
-      <% const modalFileName = button.label.replace(/ /g, '') + 'Modal' %>
+<% allCustomButtons.forEach((button) => { -%>
+  <% if (button.needsModal) { -%>
+    <% const modalFileName = button.label.replace(/ /g, '') + 'Modal' %>
 import <%- modalFileName %> from "./<%- modalFileName %>"
 <% }}) -%>
 

--- a/test/generator-add-action-cf-admin.test.js
+++ b/test/generator-add-action-cf-admin.test.js
@@ -45,7 +45,7 @@ describe('prototype', () => {
 })
 
 /**
- * Checks that all files have been generated.
+ * Checks that all the files are generated.
  *
  * @param {string} actionName an action name
  */
@@ -87,7 +87,7 @@ function assertManifestContent (actionName) {
 }
 
 /**
- * Checks that .env has the API_ENDPOINT environment variable.
+ * Checks that .env has the required environment variables.
  */
 function assertEnvContent () {
   const theFile = '.env'

--- a/test/generator-add-action-cf-admin.test.js
+++ b/test/generator-add-action-cf-admin.test.js
@@ -1,0 +1,166 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* eslint-disable jest/expect-expect */
+
+const helpers = require('yeoman-test')
+/* eslint-disable-next-line node/no-unpublished-require */
+const assert = require('yeoman-assert')
+/* eslint-disable-next-line node/no-unpublished-require */
+const cloneDeep = require('lodash.clonedeep')
+/* eslint-disable-next-line node/no-unpublished-require */
+const yaml = require('js-yaml')
+const fs = require('fs')
+const { ActionGenerator, constants } = require('@adobe/generator-app-common-lib')
+const CFAdminActionGenerator = require('../src/generator-add-action-cf-admin')
+const path = require('path')
+
+const { customExtensionManifest, demoExtensionManifest } = require('./test-manifests')
+
+const extFolder = 'src/aem-cf-console-admin-1'
+const actionFolder = path.join(extFolder, 'actions')
+const extConfigPath = path.join(extFolder, 'ext.config.yaml')
+const actionName = 'generic'
+
+const basicGeneratorOptions = {
+  'action-folder': actionFolder,
+  'config-path': extConfigPath,
+  'full-key-to-manifest': 'runtimeManifest',
+  'action-name': actionName,
+  'extension-manifest': customExtensionManifest
+}
+
+describe('prototype', () => {
+  test('exports a yeoman generator', () => {
+    expect(CFAdminActionGenerator.prototype).toBeInstanceOf(ActionGenerator)
+  })
+})
+
+/**
+ * Checks that all files have been generated.
+ *
+ * @param {string} actionName an action name
+ */
+function assertGeneratedFiles (actionName) {
+  assert.file(basicGeneratorOptions['config-path'])
+
+  assert.file(`${basicGeneratorOptions['action-folder']}/${actionName}/index.js`)
+
+  // assert.file(`test/${actionName}.test.js`)
+  assert.file(`${extFolder}/e2e/${actionName}.e2e.test.js`)
+
+  assert.file(`${basicGeneratorOptions['action-folder']}/utils.js`)
+  assert.file(`${extFolder}/test/utils.test.js`)
+}
+
+/**
+ * Checks that a correct action section has been added to the App Builder project configuration file.
+ *
+ * @param {string} actionName an action name
+ */
+function assertManifestContent (actionName) {
+  const json = yaml.load(fs.readFileSync(basicGeneratorOptions['config-path']).toString())
+  expect(json.runtimeManifest.packages).toBeDefined() // basicGeneratorOptions['full-key-to-manifest']
+  const packages = json.runtimeManifest.packages
+  // a random package name is generated, we need to figure it out
+  const packageName = Object.keys(packages)[0]
+  expect(json.runtimeManifest.packages[packageName].actions[actionName]).toEqual({
+    function: `actions/${actionName}/index.js`,
+    web: 'yes',
+    runtime: 'nodejs:14',
+    inputs: {
+      LOG_LEVEL: 'debug',
+      API_ENDPOINT: '$API_ENDPOINT'
+    },
+    annotations: {
+      'final': true,
+      'require-adobe-auth': false
+    }
+  })
+}
+
+/**
+ * Checks that package.json has all needed dependencies specified.
+ *
+ * @param {object} dependencies An object representing expected package.json dependencies.
+ * @param {object} devDependencies An object representing expected package.json dev dependencies.
+ */
+function assertDependencies (dependencies, devDependencies) {
+  expect(JSON.parse(fs.readFileSync('package.json').toString())).toEqual(expect.objectContaining({
+    dependencies,
+    devDependencies
+  }))
+}
+
+/**
+ * Checks that .env has the API_ENDPOINT environment variable.
+ */
+function assertEnvContent () {
+  const theFile = '.env'
+  assert.fileContent(
+    theFile,
+    '#API_ENDPOINT='
+  )
+}
+
+/**
+ * Checks that an action file contains correct code snippets.
+ *
+ * @param {string} actionName an action name
+ */
+function assertActionCodeContent (actionName) {
+  const theFile = `${basicGeneratorOptions['action-folder']}/${actionName}/index.js`
+  assert.fileContent(
+    theFile,
+    'const apiEndpoint = `${params.API_ENDPOINT}`'
+  )
+  assert.fileContent(
+    theFile,
+    'const requiredHeaders = [\'Authorization\']'
+  )
+}
+
+describe('run', () => {
+  test('test a generator invocation with custom code generation', async () => {
+    const options = cloneDeep(basicGeneratorOptions)
+    await helpers.run(CFAdminActionGenerator)
+      .withOptions(options)
+      .inTmpDir(dir => {
+        // ActionGenerator expects to have the ".env" file created
+        fs.writeFileSync('.env', '')
+      })
+
+    assertGeneratedFiles(actionName)
+    assertManifestContent(actionName)
+    assertActionCodeContent(actionName)
+    assertDependencies({ 'node-fetch': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
+    assertEnvContent()
+  })
+
+  test('test a generator invocation with demo code generation', async () => {
+    const actionName = 'export-to-slack'
+    const options = cloneDeep(basicGeneratorOptions)
+    options['action-name'] = actionName
+    options['extension-manifest'] = demoExtensionManifest
+    await helpers.run(CFAdminActionGenerator)
+      .withOptions(options)
+      .inTmpDir(dir => {
+        // ActionGenerator expects to have the ".env" file created
+        fs.writeFileSync('.env', '')
+      })
+
+    assertGeneratedFiles(actionName)
+    // assertManifestContent(actionName)
+    // assertActionCodeContent(actionName)
+    assertDependencies({ 'node-fetch': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
+    // assertEnvContent()
+  })
+})

--- a/test/generator-add-action-cf-admin.test.js
+++ b/test/generator-add-action-cf-admin.test.js
@@ -70,7 +70,6 @@ function assertManifestContent (actionName) {
   const json = yaml.load(fs.readFileSync(basicGeneratorOptions['config-path']).toString())
   expect(json.runtimeManifest.packages).toBeDefined() // basicGeneratorOptions['full-key-to-manifest']
   const packages = json.runtimeManifest.packages
-  // a random package name is generated, we need to figure it out
   const packageName = Object.keys(packages)[0]
   expect(json.runtimeManifest.packages[packageName].actions[actionName]).toEqual({
     function: `actions/${actionName}/index.js`,
@@ -85,19 +84,6 @@ function assertManifestContent (actionName) {
       'require-adobe-auth': false
     }
   })
-}
-
-/**
- * Checks that package.json has all needed dependencies specified.
- *
- * @param {object} dependencies An object representing expected package.json dependencies.
- * @param {object} devDependencies An object representing expected package.json dev dependencies.
- */
-function assertDependencies (dependencies, devDependencies) {
-  expect(JSON.parse(fs.readFileSync('package.json').toString())).toEqual(expect.objectContaining({
-    dependencies,
-    devDependencies
-  }))
 }
 
 /**
@@ -141,7 +127,11 @@ describe('run', () => {
     assertGeneratedFiles(actionName)
     assertManifestContent(actionName)
     assertActionCodeContent(actionName)
-    assertDependencies({ 'node-fetch': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
+    assertDependencies(
+      fs,
+      { 'node-fetch': expect.any(String) }, 
+      { '@openwhisk/wskdebug': expect.any(String) }
+    )
     assertEnvContent()
   })
 
@@ -158,9 +148,10 @@ describe('run', () => {
       })
 
     assertGeneratedFiles(actionName)
-    // assertManifestContent(actionName)
-    // assertActionCodeContent(actionName)
-    assertDependencies({ 'node-fetch': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    // assertEnvContent()
+    assertDependencies(
+      fs,
+      { 'node-fetch': expect.any(String) }, 
+      { '@openwhisk/wskdebug': expect.any(String) }
+    )
   })
 })

--- a/test/generator-add-web-assets-cf-admin.test.js
+++ b/test/generator-add-web-assets-cf-admin.test.js
@@ -89,6 +89,42 @@ function assertFiles (extensionManifest) {
     `${webSrcFolder}/index.html`,
     '<script src="./src/index.js"'
   )
+
+  const actionBarButtons = extensionManifest.actionBarButtons || []
+  const headerMenuButtons = extensionManifest.headerMenuButtons || []
+  const allCustomButtons = actionBarButtons.concat(headerMenuButtons)
+
+  allCustomButtons.forEach((button) => {
+    if (button.needsModal) {
+      const modalFileName = button.label.replace(/ /g, '') + 'Modal'
+      
+      assert.fileContent(
+        `${webSrcFolder}/src/components/App.js`,
+        `import ${modalFileName} from "./${modalFileName}"`
+      )
+      assert.fileContent(
+        `${webSrcFolder}/src/components/App.js`,
+        `element={<${button.label.replace(/ /g, '')}Modal />}`
+      )
+      assert.fileContent(
+        `${webSrcFolder}/src/components/${modalFileName}.js`,
+        `export default function ${modalFileName} ()`
+      )
+    }
+  })
+
+  headerMenuButtons.forEach((button) => {
+    if (button.needsModal) {
+      assert.fileContent(
+        `${webSrcFolder}/src/components/App.js`,
+        `exact path="${button.id}-modal"`
+      )
+      assert.fileContent(
+        `${webSrcFolder}/src/components/ExtensionRegistration.js`,
+        `const modalURL = "/index.html#/${button.id}-modal"`
+      )
+    }
+  })
 }
 
 describe('run', () => {

--- a/test/generator-add-web-assets-cf-admin.test.js
+++ b/test/generator-add-web-assets-cf-admin.test.js
@@ -37,10 +37,18 @@ describe('prototype', () => {
   })
 })
 
+/**
+ * Checks that .env has the required environment variables.
+ */
 function assertEnvContent (prevContent) {
   assert.fileContent('.env', prevContent)
 }
 
+/**
+ * Checks that all the files are generated.
+ *
+ * @param {string} extensionManifest an extension manifest
+ */
 function assertFiles (extensionManifest) {
   // Asert generated web assets files
   assert.file(`${webSrcFolder}/index.html`)
@@ -66,9 +74,26 @@ function assertFiles (extensionManifest) {
   })
 }
 
-const prevDotEnv = 'FAKECONTENT'
+/**
+ * Checks that files contains the correct code snippets.
+ *
+ * @param {string} extensionManifest an extension manifest
+ */
+ function assertCodeContent (extensionManifest) {
+  assert.fileContent(
+    `${webSrcFolder}/src/components/Constants.js`,
+    `extensionId: '${extensionManifest.id}'`
+  )
+  
+  assert.fileContent(
+    `${webSrcFolder}/index.html`,
+    '<script src="./src/index.js"'
+  )
+}
 
 describe('run', () => {
+  const prevDotEnv = 'FAKECONTENT'
+  
   test('test a generator invocation with custom code generation', async () => {
     const options = cloneDeep(basicGeneratorOptions)
     options['extension-manifest'] = customExtensionManifest
@@ -108,9 +133,7 @@ describe('run', () => {
       }
     )
     assertEnvContent(prevDotEnv)
-
-    // make sure html calls js files
-    assert.fileContent(`${webSrcFolder}/index.html`, '<script src="./src/index.js"')
+    assertCodeContent(customExtensionManifest)
   })
 
   test('test a generator invocation with demo code generation', async () => {
@@ -152,8 +175,6 @@ describe('run', () => {
       }
     )
     assertEnvContent(prevDotEnv)
-
-    // make sure html calls js files
-    assert.fileContent(`${webSrcFolder}/index.html`, '<script src="./src/index.js"')
+    assertCodeContent(demoExtensionManifest)
   })
 })

--- a/test/generator-add-web-assets-cf-admin.test.js
+++ b/test/generator-add-web-assets-cf-admin.test.js
@@ -1,0 +1,176 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* eslint-disable jest/expect-expect */ // => use assert
+
+const helpers = require('yeoman-test')
+const assert = require('yeoman-assert')
+const fs = require('fs')
+const path = require('path')
+const cloneDeep = require('lodash.clonedeep')
+
+const CFAdminWebAssetsGenerator = require('../src/generator-add-web-assets-cf-admin')
+const Generator = require('yeoman-generator')
+
+const { customExtensionManifest, demoExtensionManifest } = require('./test-manifests')
+
+const extFolder = 'src/aem-cf-console-admin-1'
+const extConfigPath = path.join(extFolder, 'ext.config.yaml')
+const webSrcFolder = path.join(extFolder, '${webSrcFolder}')
+
+const basicGeneratorOptions = {
+  'web-src-folder': webSrcFolder,
+  'config-path': extConfigPath,
+  'extension-manifest': customExtensionManifest
+}
+
+describe('prototype', () => {
+  test('exports a yeoman generator', () => {
+    expect(CFAdminWebAssetsGenerator.prototype).toBeInstanceOf(Generator)
+  })
+})
+
+function assertEnvContent (prevContent) {
+  assert.fileContent('.env', prevContent)
+}
+
+function assertFiles () {
+  assert.file(`${webSrcFolder}/index.html`)
+  assert.file(`${webSrcFolder}/src/exc-runtime.js`)
+  assert.file(`${webSrcFolder}/src/index.css`)
+  assert.file(`${webSrcFolder}/src/index.js`)
+  assert.file(`${webSrcFolder}/src/utils.js`)
+  assert.file(`${webSrcFolder}/src/components/Constants.js`)
+  assert.file(`${webSrcFolder}/src/components/Spinner.js`)
+  assert.file(`${webSrcFolder}/src/components/App.js`)
+  assert.file(`${webSrcFolder}/src/components/ExtensionRegistration.js`)
+}
+
+function assertWithActions () {
+  
+}
+
+function assertWithNoActions () {
+
+}
+
+function assertWithDoc () {
+  
+}
+
+const prevDotEnv = 'FAKECONTENT'
+
+describe('run', () => {
+  test('test a generator invocation with custom code generation', async () => {
+    // const options = cloneDeep(global.basicGeneratorOptions)
+    // options['web-src-folder'] = path.join(this.extFolder, '${webSrcFolder}')
+    const options = cloneDeep(basicGeneratorOptions)
+    await helpers
+      .run(CFAdminWebAssetsGenerator)
+      .withOptions(options)
+      .inTmpDir((dir) => {
+        fs.writeFileSync(path.join(dir, '.env'), prevDotEnv)
+      })
+
+    assertFiles()
+    assertDependencies(
+      fs,
+      {
+        '@adobe/aio-sdk': expect.any(String),
+        '@adobe/exc-app': expect.any(String),
+        '@adobe/react-spectrum': expect.any(String),
+        '@adobe/uix-guest': expect.any(String),
+        '@react-spectrum/list': expect.any(String),
+        '@spectrum-icons/workflow': expect.any(String),
+        'core-js': expect.any(String),
+        'node-fetch': expect.any(String),
+        'node-html-parser': expect.any(String),
+        'react': expect.any(String),
+        'react-dom': expect.any(String),
+        'react-error-boundary': expect.any(String),
+        'react-router-dom': expect.any(String),
+        'regenerator-runtime': expect.any(String),
+      },
+      {
+        '@babel/core': expect.any(String),
+        '@babel/plugin-transform-react-jsx': expect.any(String),
+        '@babel/polyfill': expect.any(String),
+        '@babel/preset-env': expect.any(String),
+        '@openwhisk/wskdebug': expect.any(String),
+        'jest': expect.any(String)
+      }
+    )
+    assertEnvContent(prevDotEnv)
+
+    // greats with projectName
+    // TODO fix check failing content mismatch, possible bug
+    // assert.fileContent('${webSrcFolder}/src/components/Home.js', 'Welcome to abc!')
+
+    // make sure html calls js files
+    assert.fileContent(`${webSrcFolder}/index.html`, '<script src="./src/index.js"')
+
+    assertWithActions()
+    assertWithDoc()
+  })
+
+  test('test a generator invocation with demo code generation', async () => {
+    // const options = cloneDeep(global.basicGeneratorOptions)
+    // options['web-src-folder'] = '${webSrcFolder}'
+    const options = cloneDeep(basicGeneratorOptions)
+    options['extension-manifest'] = demoExtensionManifest
+    await helpers
+      .run(CFAdminWebAssetsGenerator)
+      .withOptions(options)
+      .inTmpDir((dir) => {
+        fs.writeFileSync(path.join(dir, '.env'), prevDotEnv)
+      })
+
+    assertFiles()
+    assertDependencies(
+      fs,
+      {
+        '@adobe/aio-sdk': expect.any(String),
+        '@adobe/exc-app': expect.any(String),
+        '@adobe/react-spectrum': expect.any(String),
+        '@adobe/uix-guest': expect.any(String),
+        '@react-spectrum/list': expect.any(String),
+        '@spectrum-icons/workflow': expect.any(String),
+        'core-js': expect.any(String),
+        'node-fetch': expect.any(String),
+        'node-html-parser': expect.any(String),
+        'react': expect.any(String),
+        'react-dom': expect.any(String),
+        'react-error-boundary': expect.any(String),
+        'react-router-dom': expect.any(String),
+        'regenerator-runtime': expect.any(String),
+      },
+      {
+        '@babel/core': expect.any(String),
+        '@babel/plugin-transform-react-jsx': expect.any(String),
+        '@babel/polyfill': expect.any(String),
+        '@babel/preset-env': expect.any(String),
+        '@openwhisk/wskdebug': expect.any(String),
+        'jest': expect.any(String)
+      }
+    )
+    assertEnvContent(prevDotEnv)
+
+    // greats with projectName
+    // TODO fix check failing content mismatch, possible bug
+    // assert.fileContent('${webSrcFolder}/src/components/Home.js', 'Welcome to abc!')
+
+    // make sure html calls js files
+    assert.fileContent(`${webSrcFolder}/index.html`, '<script src="./src/index.js"')
+
+    assertWithNoActions()
+    assertWithDoc()
+  })
+})

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,10 +1,88 @@
 const helpers = require('yeoman-test')
-
-const cfConsoleAdmin = require.resolve('../src/index')
 const Generator = require('yeoman-generator')
+
+const CFAdminMainGenerator = require('../src/index')
+const CFAdminActionGenerator = require('../src/generator-add-action-cf-admin')
+const CFAdminWebAssetsGenerator = require('../src/generator-add-web-assets-cf-admin')
+const { utils } = require('@adobe/generator-app-common-lib')
+
+const { defaultExtensionManifest, customExtensionManifest } = require('./test-manifests')
+
+const composeWith = jest.spyOn(Generator.prototype, 'composeWith').mockImplementation(jest.fn())
+const prompt = jest.spyOn(Generator.prototype, 'prompt') // prompt answers are mocked by "yeoman-test"
+const writeKeyAppConfig = jest.spyOn(utils, 'writeKeyAppConfig').mockImplementation(jest.fn())
+const writeKeyYAMLConfig = jest.spyOn(utils, 'writeKeyYAMLConfig').mockImplementation(jest.fn())
+
+beforeEach(() => {
+  composeWith.mockClear()
+  prompt.mockClear()
+  writeKeyAppConfig.mockClear()
+  writeKeyYAMLConfig.mockClear()
+})
 
 describe('prototype', () => {
   test('exports a yeoman generator', () => {
-    expect(require(cfConsoleAdmin).prototype).toBeInstanceOf(Generator)
+    expect(CFAdminMainGenerator.prototype).toBeInstanceOf(Generator)
+  })
+})
+
+describe('run', () => {
+  
+  test('test a generator invocation with default code generation', async () => {
+    const templateFolder = 'src/aem-cf-console-admin-1'
+    const options = {
+      'is-test': true,
+      'extension-manifest': defaultExtensionManifest
+    }
+    await helpers.run(CFAdminMainGenerator)
+      .withOptions(options)
+    expect(prompt).not.toHaveBeenCalled()
+    expect(composeWith).toHaveBeenCalledTimes(1)
+    expect(composeWith).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Generator: CFAdminWebAssetsGenerator,
+        path: 'unknown'
+      }),
+      expect.any(Object)
+    )
+  })
+
+  test('test a generator invocation with custom code generation', async () => {
+    const templateFolder = 'src/aem-cf-console-admin-1'
+    const options = {
+      'is-test': true,
+      'extension-manifest': customExtensionManifest
+    }
+    await helpers.run(CFAdminMainGenerator)
+      .withOptions(options)
+    expect(prompt).not.toHaveBeenCalled()
+    expect(composeWith).toHaveBeenCalledTimes(3)
+    expect(composeWith).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Generator: CFAdminActionGenerator,
+        path: 'unknown'
+      }),
+      expect.any(Object)
+    )
+    expect(composeWith).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Generator: CFAdminActionGenerator,
+        path: 'unknown'
+      }),
+      expect.any(Object)
+    )
+    expect(composeWith).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Generator: CFAdminWebAssetsGenerator,
+        path: 'unknown'
+      }),
+      expect.any(Object)
+    )
+    expect(writeKeyAppConfig).toHaveBeenCalledTimes(1)
+    expect(writeKeyYAMLConfig).toHaveBeenCalledTimes(3)
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), 'extensions.aem/cf-console-admin/1', { $include: `${templateFolder}/ext.config.yaml` })
+    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${templateFolder}/ext.config.yaml`), 'operations', { view: [{ impl: 'index.html', type: 'web' }] })
+    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${templateFolder}/ext.config.yaml`), 'actions', 'actions')
+    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${templateFolder}/ext.config.yaml`), 'web', 'web-src')
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -45,6 +45,12 @@ describe('run', () => {
       }),
       expect.any(Object)
     )
+    expect(writeKeyAppConfig).toHaveBeenCalledTimes(1)
+    expect(writeKeyYAMLConfig).toHaveBeenCalledTimes(3)
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), 'extensions.aem/cf-console-admin/1', { $include: `${templateFolder}/ext.config.yaml` })
+    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${templateFolder}/ext.config.yaml`), 'operations', { view: [{ impl: 'index.html', type: 'web' }] })
+    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${templateFolder}/ext.config.yaml`), 'actions', 'actions')
+    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${templateFolder}/ext.config.yaml`), 'web', 'web-src')
   })
 
   test('test a generator invocation with custom code generation', async () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -27,9 +27,11 @@ describe('prototype', () => {
 })
 
 describe('run', () => {
+  const srcFolder = 'src/aem-cf-console-admin-1'
+  const configName = 'aem/cf-console-admin/1'
+  const extConfig = 'ext.config.yaml'
   
   test('test a generator invocation with default code generation', async () => {
-    const templateFolder = 'src/aem-cf-console-admin-1'
     const options = {
       'is-test': true,
       'extension-manifest': defaultExtensionManifest
@@ -47,14 +49,13 @@ describe('run', () => {
     )
     expect(writeKeyAppConfig).toHaveBeenCalledTimes(1)
     expect(writeKeyYAMLConfig).toHaveBeenCalledTimes(3)
-    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), 'extensions.aem/cf-console-admin/1', { $include: `${templateFolder}/ext.config.yaml` })
-    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${templateFolder}/ext.config.yaml`), 'operations', { view: [{ impl: 'index.html', type: 'web' }] })
-    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${templateFolder}/ext.config.yaml`), 'actions', 'actions')
-    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${templateFolder}/ext.config.yaml`), 'web', 'web-src')
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), `extensions.${configName}`, { $include: `${srcFolder}/${extConfig}` })
+    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${srcFolder}/${extConfig}`), 'operations', { view: [{ impl: 'index.html', type: 'web' }] })
+    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${srcFolder}/${extConfig}`), 'actions', 'actions')
+    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${srcFolder}/${extConfig}`), 'web', 'web-src')
   })
 
   test('test a generator invocation with custom code generation', async () => {
-    const templateFolder = 'src/aem-cf-console-admin-1'
     const options = {
       'is-test': true,
       'extension-manifest': customExtensionManifest
@@ -86,9 +87,9 @@ describe('run', () => {
     )
     expect(writeKeyAppConfig).toHaveBeenCalledTimes(1)
     expect(writeKeyYAMLConfig).toHaveBeenCalledTimes(3)
-    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), 'extensions.aem/cf-console-admin/1', { $include: `${templateFolder}/ext.config.yaml` })
-    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${templateFolder}/ext.config.yaml`), 'operations', { view: [{ impl: 'index.html', type: 'web' }] })
-    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${templateFolder}/ext.config.yaml`), 'actions', 'actions')
-    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${templateFolder}/ext.config.yaml`), 'web', 'web-src')
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), `extensions.${configName}`, { $include: `${srcFolder}/${extConfig}` })
+    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${srcFolder}/${extConfig}`), 'operations', { view: [{ impl: 'index.html', type: 'web' }] })
+    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${srcFolder}/${extConfig}`), 'actions', 'actions')
+    expect(writeKeyYAMLConfig).toHaveBeenCalledWith(expect.any(CFAdminMainGenerator), global.n(`${srcFolder}/${extConfig}`), 'web', 'web-src')
   })
 })

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const { stdout, stderr } = require('stdout-stderr')
 
 process.on('unhandledRejection', error => {
@@ -15,3 +16,14 @@ afterEach(() => {
   stdout.stop()
   stderr.stop()
 })
+
+// quick normalization to test windows/unix paths
+global.n = p => path.normalize(p)
+global.r = p => path.resolve(p)
+
+global.assertDependencies = (fs, dependencies, devDependencies) => {
+  expect(JSON.parse(fs.readFileSync('package.json').toString())).toEqual(expect.objectContaining({
+    dependencies,
+    devDependencies
+  }))
+}

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -21,6 +21,12 @@ afterEach(() => {
 global.n = p => path.normalize(p)
 global.r = p => path.resolve(p)
 
+/**
+ * Checks that package.json has all needed dependencies specified.
+ *
+ * @param {object} dependencies An object representing expected package.json dependencies.
+ * @param {object} devDependencies An object representing expected package.json dev dependencies.
+ */
 global.assertDependencies = (fs, dependencies, devDependencies) => {
   expect(JSON.parse(fs.readFileSync('package.json').toString())).toEqual(expect.objectContaining({
     dependencies,

--- a/test/test-manifests.js
+++ b/test/test-manifests.js
@@ -1,0 +1,87 @@
+const defaultExtensionManifest = {
+  "name": "CF Admin Console Test Extension",
+  "id": "cf-admin-console-test-extension",
+  "description": "Test Extension for AEM Content Fragment Admin Console",
+  "version": "0.0.1"
+}
+
+const customExtensionManifest = {
+  "name": "CF Admin Console Test Extension",
+  "id": "cf-admin-console-test-extension",
+  "description": "Test Extension for AEM Content Fragment Admin Console",
+  "version": "0.0.1",
+  "actionBarButtons": [
+    {
+      "label": "Export",
+      "needsModal": false,
+      "id": "export"
+    }
+  ],
+  "headerMenuButtons": [
+    {
+      "label": "Import",
+      "needsModal": true,
+      "id": "import"
+    }
+  ],
+  "runtimeActions": [
+    {
+      "name": "import"
+    },
+    {
+      "name": "export"
+    }
+  ]
+}
+
+const demoExtensionManifest = {
+  "name": "Slack Import/Export Extension Demo",
+  "id": "slack-import-export-extension-demo",
+  "description": "Demo Extension to showcase import/export functionality using custom buttons within AEM Content Fragment Console",
+  "version": "1.0.0",
+  "templateFolder": "slack-demo",
+  "actionBarButtons": [
+    {
+      "label": "Export to Slack",
+      "needsModal": true,
+      "id": "export-to-slack"
+    }
+  ],
+  "headerMenuButtons": [
+    {
+      "label": "Slack Settings",
+      "needsModal": true,
+      "id": "slack-settings"
+    }
+  ],
+  "runtimeActions": [
+    {
+      "name": "export-to-slack"
+    },
+    {
+      "name": "get-slack-config"
+    },
+    {
+      "name": "get-slack-channels"
+    },
+    {
+      "name": "import-from-slack"
+    },
+    {
+      "name": "create-new-fragments"
+    }
+  ],
+  "templateInputs": {
+    "LOG_LEVEL": "debug",
+    "SLACK_WEBHOOK": "$SLACK_WEBHOOK",
+    "SLACK_CHANNEL": "$SLACK_CHANNEL",
+    "SLACK_OAUTH_TOKEN": "$SLACK_OAUTH_TOKEN"
+  },
+  "templateDotEnvVars": ["SLACK_WEBHOOK", "SLACK_CHANNEL", "SLACK_OAUTH_TOKEN"]
+}
+
+module.exports = {
+  defaultExtensionManifest,
+  customExtensionManifest,
+  demoExtensionManifest
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR introduces the following changes to the `Extensibility Template for AEM Content Fragment Admin Console` template:

<!--- Describe your changes in detail -->
- the template now has unit tests to provide test coverage for the generator files.
- the template will now show the docs URL to help you configure the demo application after finishing the project initialization.

## Related Issue
[DEVX-2622](https://jira.corp.adobe.com/browse/DEVX-2622)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
To prevent breaking the existing functionalities of the template.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
There are minimal changes to the generators to incorporate the unit tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
