### PR TITLE
Added changes to update @adobe/generator-app-common-lib to v0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aem-cf-admin-ui-ext-tpl",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "main": "src/index.js",
   "description": "Extensibility template for AEM Content Fragment Admin Console",
   "engines": {
@@ -12,8 +12,7 @@
   "author": "Adobe Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/generator-add-action-generic": "^0.2.3",
-    "@adobe/generator-app-common-lib": "^0.3.1",
+    "@adobe/generator-app-common-lib": "^0.3.3",
     "chalk": "^4.0.0",
     "fs-extra": "^10.1.0",
     "slugify": "^1.6.5",

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 const Generator = require('yeoman-generator')
 const path = require('path')
 const upath = require('upath')
-const fs = require('fs-extra')
+// const fs = require('fs-extra')
 const chalk = require('chalk')
 
 const CFAdminActionGenerator = require('./generator-add-action-cf-admin')

--- a/test/generator-add-action-cf-admin.test.js
+++ b/test/generator-add-action-cf-admin.test.js
@@ -9,20 +9,18 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-/* eslint-disable jest/expect-expect */
-
 const helpers = require('yeoman-test')
-/* eslint-disable-next-line node/no-unpublished-require */
 const assert = require('yeoman-assert')
-/* eslint-disable-next-line node/no-unpublished-require */
 const cloneDeep = require('lodash.clonedeep')
-/* eslint-disable-next-line node/no-unpublished-require */
+
 const yaml = require('js-yaml')
 const fs = require('fs')
-const { ActionGenerator, constants } = require('@adobe/generator-app-common-lib')
-const CFAdminActionGenerator = require('../src/generator-add-action-cf-admin')
 const path = require('path')
 
+const CFAdminActionGenerator = require('../src/generator-add-action-cf-admin')
+
+const { ActionGenerator, constants } = require('@adobe/generator-app-common-lib')
+const { runtimeManifestKey, defaultRuntimeKind } = constants
 const { customExtensionManifest, demoExtensionManifest } = require('./test-manifests')
 
 const extFolder = 'src/aem-cf-console-admin-1'
@@ -33,7 +31,7 @@ const actionName = 'generic'
 const basicGeneratorOptions = {
   'action-folder': actionFolder,
   'config-path': extConfigPath,
-  'full-key-to-manifest': 'runtimeManifest',
+  'full-key-to-manifest': runtimeManifestKey,
   'action-name': actionName,
   'extension-manifest': customExtensionManifest
 }
@@ -74,7 +72,7 @@ function assertManifestContent (actionName) {
   expect(json.runtimeManifest.packages[packageName].actions[actionName]).toEqual({
     function: `actions/${actionName}/index.js`,
     web: 'yes',
-    runtime: 'nodejs:14',
+    runtime: defaultRuntimeKind,
     inputs: {
       LOG_LEVEL: 'debug',
       API_ENDPOINT: '$API_ENDPOINT'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Quick fix related to assert failing for expected `runtime` in the manifest (app.config.yaml).
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
To fix a failing assert when submitting the template to the template registry during the validation step.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Modified the unit tests and tested it locally.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
