### PR TITLE
Fix for preview URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aem-cf-admin-ui-ext-tpl",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "src/index.js",
   "description": "Extensibility template for AEM Content Fragment Admin Console",
   "engines": {

--- a/src/templates/hooks/post-deploy.js
+++ b/src/templates/hooks/post-deploy.js
@@ -7,7 +7,6 @@ module.exports = (config) => {
     const yamlFile = fs.readFileSync(`${config.root}/app.config.yaml`, 'utf8')
     const yamlData = yaml.load(yamlFile)
     const { extensions } = yamlData
-    console.log(extensions);
     const appUrl = `https://${config.ow.namespace}.${config.app.hostname}`
 
     // For now we are ok just to read the first extension point to build the preview link

--- a/src/templates/hooks/post-deploy.js
+++ b/src/templates/hooks/post-deploy.js
@@ -1,8 +1,21 @@
 const chalk = require('chalk')
+const fs = require('fs')
+const yaml = require('js-yaml')
 
 module.exports = (config) => {
     console.log(chalk.magenta(chalk.bold('For a developer preview of your UI extension in the AEM environment, follow the URL:')))
-    const appUrl =  `https://${config.ow.namespace}.${config.app.hostname}`
-    const base64EncodedUrl = Buffer.from(appUrl).toString('base64')
-    console.log(chalk.magenta(chalk.bold(`  -> https://experience.adobe.com/aem/extension-manager/preview/${base64EncodedUrl}`)))
+    const yamlFile = fs.readFileSync(`${config.root}/app.config.yaml`, 'utf8')
+    const yamlData = yaml.load(yamlFile)
+    const { extensions } = yamlData
+    console.log(extensions);
+    const appUrl = `https://${config.ow.namespace}.${config.app.hostname}`
+
+    // For now we are ok just to read the first extension point to build the preview link
+    const extension = Object.keys(extensions)[0]
+    const previewData = {
+      extensionPoint: extension,
+      url: appUrl,
+    };
+    const base64EncodedData = Buffer.from(JSON.stringify(previewData)).toString('base64')
+    console.log(chalk.magenta(chalk.bold(`  -> https://experience.adobe.com/aem/extension-manager/preview/${base64EncodedData}`)))
 };

--- a/src/templates/hooks/post-deploy.js
+++ b/src/templates/hooks/post-deploy.js
@@ -1,20 +1,29 @@
-const chalk = require('chalk')
-const fs = require('fs')
-const yaml = require('js-yaml')
+const chalk = require('chalk');
+const fs = require('fs');
+const yaml = require('js-yaml');
 
 module.exports = (config) => {
-    console.log(chalk.magenta(chalk.bold('For a developer preview of your UI extension in the AEM environment, follow the URL:')))
-    const yamlFile = fs.readFileSync(`${config.root}/app.config.yaml`, 'utf8')
-    const yamlData = yaml.load(yamlFile)
-    const { extensions } = yamlData
-    const appUrl = `https://${config.ow.namespace}.${config.app.hostname}`
+  try {
+    // read the app.config.yaml file to get the extension points
+    const yamlFile = fs.readFileSync(`${config.root}/app.config.yaml`, 'utf8');
+    const yamlData = yaml.load(yamlFile);
+    const { extensions } = yamlData;
 
     // For now we are ok just to read the first extension point to build the preview link
-    const extension = Object.keys(extensions)[0]
+    const extension = Object.keys(extensions)[0];
     const previewData = {
       extensionPoint: extension,
-      url: appUrl,
+      url: config.project.workspace.app_url,
     };
-    const base64EncodedData = Buffer.from(JSON.stringify(previewData)).toString('base64')
-    console.log(chalk.magenta(chalk.bold(`  -> https://experience.adobe.com/aem/extension-manager/preview/${base64EncodedData}`)))
+
+    // buid the preview URL
+    const base64EncodedData = Buffer.from(JSON.stringify(previewData)).toString('base64');
+    console.log(chalk.magenta(chalk.bold('For a developer preview of your UI extension in the AEM environment, follow the URL:')));
+
+    // check if the environment is stage, if so, we need to add the -stage suffix to the URL
+    const env = process.env.AIO_CLI_ENV === 'stage' ? '-stage' : '';
+    console.log(chalk.magenta(chalk.bold(`  -> https://experience${env}.adobe.com/aem/extension-manager/preview/${base64EncodedData}`)));
+  } catch (error) {
+    // if something went wrong, we do nothing, and just don't display the URL
+  }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The way how the Preview works was changed in the Extension Manager, now it expects an object, not just a URL.


## Motivation and Context

Fix for the hook to support building a JSON object instead of a URL.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
