### PR TITLE
Add metadata generation hooks and metadata registration

### DIFF
--- a/src/generator-add-web-assets-cf-admin.js
+++ b/src/generator-add-web-assets-cf-admin.js
@@ -65,6 +65,10 @@ class CFAdminWebAssetsGenerator extends Generator {
     this.fs.writeJSON(this.destinationPath('.babelrc'), {
       plugins: ['@babel/plugin-transform-react-jsx']
     })
+
+    //generate default metadata
+    this.fs.writeJSON('src/app-metadata.json', {});
+
     // add dependencies
     utils.addDependencies(this, {
       '@adobe/aio-sdk': commonDependencyVersions['@adobe/aio-sdk'],

--- a/src/generator-add-web-assets-cf-admin.js
+++ b/src/generator-add-web-assets-cf-admin.js
@@ -70,7 +70,7 @@ class CFAdminWebAssetsGenerator extends Generator {
       '@adobe/aio-sdk': commonDependencyVersions['@adobe/aio-sdk'],
       '@adobe/exc-app': '^0.2.21',
       '@adobe/react-spectrum': '^3.4.0',
-      '@adobe/uix-guest': '^0.8.0',
+      '@adobe/uix-guest': '^0.10.0',
       '@react-spectrum/list': '^3.0.0-rc.0',
       '@spectrum-icons/workflow': '^3.2.0',
       'chalk': '^4',
@@ -81,7 +81,9 @@ class CFAdminWebAssetsGenerator extends Generator {
       'react-dom': '^16.13.1',
       'react-error-boundary': '^1.2.5',
       'react-router-dom': '^6.3.0',
-      'regenerator-runtime': '^0.13.5'
+      'regenerator-runtime': '^0.13.5',
+      "ajv": "^8.12.0",
+      "js-yaml": "^4.1.0"
     })
     utils.addDependencies(
       this,
@@ -94,6 +96,12 @@ class CFAdminWebAssetsGenerator extends Generator {
         'jest': '^27.2.4'
       },
       true
+    )
+    utils.addPkgScript(
+      this,
+      {
+        "transform:yaml-to-json": "node node_modules/@adobe/uix-guest/scripts/generate-metadata.js"
+      }
     )
   }
 

--- a/src/generator-add-web-assets-cf-admin.js
+++ b/src/generator-add-web-assets-cf-admin.js
@@ -70,7 +70,7 @@ class CFAdminWebAssetsGenerator extends Generator {
       '@adobe/aio-sdk': commonDependencyVersions['@adobe/aio-sdk'],
       '@adobe/exc-app': '^0.2.21',
       '@adobe/react-spectrum': '^3.4.0',
-      '@adobe/uix-guest': '^0.10.0',
+      '@adobe/uix-guest': '^0.10.3',
       '@react-spectrum/list': '^3.0.0-rc.0',
       '@spectrum-icons/workflow': '^3.2.0',
       'chalk': '^4',

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,9 @@ class MainGenerator extends Generator {
   }
 
   async writing () {
+    //generate default metadata
+    this.fs.writeJSON('src/app-metadata.json', {});
+
     // generate the generic action
     if (this.extensionManifest.runtimeActions) {
       this.extensionManifest.runtimeActions.forEach((action) => {
@@ -139,6 +142,8 @@ class MainGenerator extends Generator {
     // add hooks path
     utils.writeKeyYAMLConfig(this, this.extConfigPath,
       'hooks', {
+        'pre-app-run': 'node node_modules/@adobe/uix-guest/scripts/generate-metadata.js',
+        'pre-app-build': 'node node_modules/@adobe/uix-guest/scripts/generate-metadata.js',
         'post-app-deploy': './hooks/post-deploy.js'
       }
     )

--- a/src/templates/_shared/stub-extension-registration.ejs
+++ b/src/templates/_shared/stub-extension-registration.ejs
@@ -17,6 +17,7 @@ function ExtensionRegistration() {
   const init = async () => {
     const guestConnection = await register({
       id: extensionId,
+      metadata,
       methods: {
         <%_ if (extensionManifest.actionBarButtons || extensionManifest.headerMenuButtons) { -%>
           <%_ if (extensionManifest.actionBarButtons) { -%>
@@ -27,7 +28,6 @@ function ExtensionRegistration() {
               <%_ extensionManifest.actionBarButtons.forEach((button) => { -%>
               {
                 'id': '<%- button.id %>',
-                'metadata': metadata,
                 'label': '<%- button.label %>',
                 'icon': 'PublishCheck',
                 onClick(selections) {

--- a/src/templates/_shared/stub-extension-registration.ejs
+++ b/src/templates/_shared/stub-extension-registration.ejs
@@ -11,6 +11,7 @@ import { generatePath } from "react-router";
 import { Text } from "@adobe/react-spectrum";
 import { register } from "@adobe/uix-guest";
 import { extensionId } from "./Constants";
+import metadata from '../../../../app-metadata.json';
 
 function ExtensionRegistration() {
   const init = async () => {
@@ -26,6 +27,7 @@ function ExtensionRegistration() {
               <%_ extensionManifest.actionBarButtons.forEach((button) => { -%>
               {
                 'id': '<%- button.id %>',
+                'metadata': metadata,
                 'label': '<%- button.label %>',
                 'icon': 'PublishCheck',
                 onClick(selections) {

--- a/test/generator-add-web-assets-cf-admin.test.js
+++ b/test/generator-add-web-assets-cf-admin.test.js
@@ -11,37 +11,40 @@ governing permissions and limitations under the License.
 
 /* eslint-disable jest/expect-expect */ // => use assert
 
-const helpers = require('yeoman-test')
-const assert = require('yeoman-assert')
-const fs = require('fs')
-const path = require('path')
-const cloneDeep = require('lodash.clonedeep')
+const helpers = require("yeoman-test");
+const assert = require("yeoman-assert");
+const fs = require("fs");
+const path = require("path");
+const cloneDeep = require("lodash.clonedeep");
 
-const CFAdminWebAssetsGenerator = require('../src/generator-add-web-assets-cf-admin')
-const Generator = require('yeoman-generator')
+const CFAdminWebAssetsGenerator = require("../src/generator-add-web-assets-cf-admin");
+const Generator = require("yeoman-generator");
 
-const { customExtensionManifest, demoExtensionManifest } = require('./test-manifests')
+const {
+  customExtensionManifest,
+  demoExtensionManifest,
+} = require("./test-manifests");
 
-const extFolder = 'src/aem-cf-console-admin-1'
-const extConfigPath = path.join(extFolder, 'ext.config.yaml')
-const webSrcFolder = path.join(extFolder, 'web-src')
+const extFolder = "src/aem-cf-console-admin-1";
+const extConfigPath = path.join(extFolder, "ext.config.yaml");
+const webSrcFolder = path.join(extFolder, "web-src");
 
 const basicGeneratorOptions = {
-  'web-src-folder': webSrcFolder,
-  'config-path': extConfigPath
-}
+  "web-src-folder": webSrcFolder,
+  "config-path": extConfigPath,
+};
 
-describe('prototype', () => {
-  test('exports a yeoman generator', () => {
-    expect(CFAdminWebAssetsGenerator.prototype).toBeInstanceOf(Generator)
-  })
-})
+describe("prototype", () => {
+  test("exports a yeoman generator", () => {
+    expect(CFAdminWebAssetsGenerator.prototype).toBeInstanceOf(Generator);
+  });
+});
 
 /**
  * Checks that .env has the required environment variables.
  */
-function assertEnvContent (prevContent) {
-  assert.fileContent('.env', prevContent)
+function assertEnvContent(prevContent) {
+  assert.fileContent(".env", prevContent);
 }
 
 /**
@@ -49,26 +52,27 @@ function assertEnvContent (prevContent) {
  *
  * @param {string} extensionManifest an extension manifest
  */
-function assertFiles (extensionManifest) {
+function assertFiles(extensionManifest) {
   // Asert generated web assets files
-  assert.file(`${webSrcFolder}/index.html`)
-  assert.file(`${webSrcFolder}/src/index.css`)
-  assert.file(`${webSrcFolder}/src/index.js`)
-  assert.file(`${webSrcFolder}/src/components/Constants.js`)
-  assert.file(`${webSrcFolder}/src/components/App.js`)
-  assert.file(`${webSrcFolder}/src/components/ExtensionRegistration.js`)
+  assert.file(`${webSrcFolder}/index.html`);
+  assert.file(`${webSrcFolder}/src/index.css`);
+  assert.file(`${webSrcFolder}/src/index.js`);
+  assert.file(`${webSrcFolder}/src/components/Constants.js`);
+  assert.file(`${webSrcFolder}/src/components/App.js`);
+  assert.file(`${webSrcFolder}/src/components/ExtensionRegistration.js`);
+  assert.file(`${webSrcFolder}/src/components/ExtensionRegistration.js`);
 
   // Assert generated modal files
-  const actionBarButtons = extensionManifest.actionBarButtons || []
-  const headerMenuButtons = extensionManifest.headerMenuButtons || []
-  const allCustomButtons = actionBarButtons.concat(headerMenuButtons)
+  const actionBarButtons = extensionManifest.actionBarButtons || [];
+  const headerMenuButtons = extensionManifest.headerMenuButtons || [];
+  const allCustomButtons = actionBarButtons.concat(headerMenuButtons);
 
   allCustomButtons.forEach((button) => {
     if (button.needsModal) {
-      const modalFileName = button.label.replace(/ /g, '') + 'Modal'
-      assert.file(`${webSrcFolder}/src/components/${modalFileName}.js`)
+      const modalFileName = button.label.replace(/ /g, "") + "Modal";
+      assert.file(`${webSrcFolder}/src/components/${modalFileName}.js`);
     }
-  })
+  });
 }
 
 /**
@@ -76,140 +80,150 @@ function assertFiles (extensionManifest) {
  *
  * @param {string} extensionManifest an extension manifest
  */
- function assertCodeContent (extensionManifest) {
+function assertCodeContent(extensionManifest) {
   assert.fileContent(
     `${webSrcFolder}/src/components/Constants.js`,
     `extensionId: '${extensionManifest.id}'`
-  )
+  );
 
   assert.fileContent(
     `${webSrcFolder}/index.html`,
     '<script src="./src/index.js"'
-  )
+  );
 
-  const actionBarButtons = extensionManifest.actionBarButtons || []
-  const headerMenuButtons = extensionManifest.headerMenuButtons || []
-  const allCustomButtons = actionBarButtons.concat(headerMenuButtons)
+  const actionBarButtons = extensionManifest.actionBarButtons || [];
+  const headerMenuButtons = extensionManifest.headerMenuButtons || [];
+  const allCustomButtons = actionBarButtons.concat(headerMenuButtons);
 
   allCustomButtons.forEach((button) => {
     if (button.needsModal) {
-      const modalFileName = button.label.replace(/ /g, '') + 'Modal'
+      const modalFileName = button.label.replace(/ /g, "") + "Modal";
 
       assert.fileContent(
         `${webSrcFolder}/src/components/App.js`,
         `import ${modalFileName} from "./${modalFileName}"`
-      )
+      );
       assert.fileContent(
         `${webSrcFolder}/src/components/App.js`,
-        `element={<${button.label.replace(/ /g, '')}Modal />}`
-      )
+        `element={<${button.label.replace(/ /g, "")}Modal />}`
+      );
       assert.fileContent(
         `${webSrcFolder}/src/components/${modalFileName}.js`,
         `export default function ${modalFileName} ()`
-      )
+      );
     }
-  })
+  });
 
   headerMenuButtons.forEach((button) => {
     if (button.needsModal) {
       assert.fileContent(
         `${webSrcFolder}/src/components/App.js`,
         `exact path="${button.id}-modal"`
-      )
+      );
       assert.fileContent(
         `${webSrcFolder}/src/components/ExtensionRegistration.js`,
         `const modalURL = "/index.html#/${button.id}-modal"`
-      )
+      );
     }
-  })
+  });
 }
 
-describe('run', () => {
-  const prevDotEnv = 'FAKECONTENT'
+describe("run", () => {
+  const prevDotEnv = "FAKECONTENT";
 
-  test('test a generator invocation with custom code generation', async () => {
-    const options = cloneDeep(basicGeneratorOptions)
-    options['extension-manifest'] = customExtensionManifest
+  test("test a generator invocation with custom code generation", async () => {
+    const options = cloneDeep(basicGeneratorOptions);
+    options["extension-manifest"] = customExtensionManifest;
     await helpers
       .run(CFAdminWebAssetsGenerator)
       .withOptions(options)
       .inTmpDir((dir) => {
-        fs.writeFileSync(path.join(dir, '.env'), prevDotEnv)
-      })
+        fs.writeFileSync(path.join(dir, ".env"), prevDotEnv);
+      });
 
-    assertFiles(customExtensionManifest)
+    assertFiles(customExtensionManifest);
     assertDependencies(
       fs,
       {
-        '@adobe/aio-sdk': expect.any(String),
-        '@adobe/exc-app': expect.any(String),
-        '@adobe/react-spectrum': expect.any(String),
-        '@adobe/uix-guest': expect.any(String),
-        '@react-spectrum/list': expect.any(String),
-        '@spectrum-icons/workflow': expect.any(String),
-        'chalk': expect.any(String),
-        'core-js': expect.any(String),
-        'node-fetch': expect.any(String),
-        'node-html-parser': expect.any(String),
-        'react': expect.any(String),
-        'react-dom': expect.any(String),
-        'react-error-boundary': expect.any(String),
-        'react-router-dom': expect.any(String),
-        'regenerator-runtime': expect.any(String),
+        "@adobe/aio-sdk": expect.any(String),
+        "@adobe/exc-app": expect.any(String),
+        "@adobe/react-spectrum": expect.any(String),
+        "@adobe/uix-guest": expect.any(String),
+        "@react-spectrum/list": expect.any(String),
+        "@spectrum-icons/workflow": expect.any(String),
+        chalk: expect.any(String),
+        "core-js": expect.any(String),
+        "node-fetch": expect.any(String),
+        "node-html-parser": expect.any(String),
+        react: expect.any(String),
+        "react-dom": expect.any(String),
+        "react-error-boundary": expect.any(String),
+        "react-router-dom": expect.any(String),
+        "regenerator-runtime": expect.any(String),
+        "ajv": expect.any(String),
+        "js-yaml": expect.any(String),
       },
       {
-        '@babel/core': expect.any(String),
-        '@babel/plugin-transform-react-jsx': expect.any(String),
-        '@babel/polyfill': expect.any(String),
-        '@babel/preset-env': expect.any(String),
-        '@openwhisk/wskdebug': expect.any(String),
-        'jest': expect.any(String)
+        "@babel/core": expect.any(String),
+        "@babel/plugin-transform-react-jsx": expect.any(String),
+        "@babel/polyfill": expect.any(String),
+        "@babel/preset-env": expect.any(String),
+        "@openwhisk/wskdebug": expect.any(String),
+        jest: expect.any(String),
       }
-    )
-    assertEnvContent(prevDotEnv)
-    assertCodeContent(customExtensionManifest)
-  })
+    );
+    assertScripts(fs, {
+      "transform:yaml-to-json": expect.any(String),
+    });
+    assertEnvContent(prevDotEnv);
+    assertCodeContent(customExtensionManifest);
+  });
 
-  test('test a generator invocation with demo code generation', async () => {
-    const options = cloneDeep(basicGeneratorOptions)
-    options['extension-manifest'] = demoExtensionManifest
+  test("test a generator invocation with demo code generation", async () => {
+    const options = cloneDeep(basicGeneratorOptions);
+    options["extension-manifest"] = demoExtensionManifest;
     await helpers
       .run(CFAdminWebAssetsGenerator)
       .withOptions(options)
       .inTmpDir((dir) => {
-        fs.writeFileSync(path.join(dir, '.env'), prevDotEnv)
-      })
+        fs.writeFileSync(path.join(dir, ".env"), prevDotEnv);
+      });
 
-    assertFiles(demoExtensionManifest)
+    assertFiles(demoExtensionManifest);
     assertDependencies(
       fs,
       {
-        '@adobe/aio-sdk': expect.any(String),
-        '@adobe/exc-app': expect.any(String),
-        '@adobe/react-spectrum': expect.any(String),
-        '@adobe/uix-guest': expect.any(String),
-        '@react-spectrum/list': expect.any(String),
-        '@spectrum-icons/workflow': expect.any(String),
-        'chalk': expect.any(String),
-        'core-js': expect.any(String),
-        'node-fetch': expect.any(String),
-        'node-html-parser': expect.any(String),
-        'react': expect.any(String),
-        'react-dom': expect.any(String),
-        'react-error-boundary': expect.any(String),
-        'react-router-dom': expect.any(String),
-        'regenerator-runtime': expect.any(String),
+        "@adobe/aio-sdk": expect.any(String),
+        "@adobe/exc-app": expect.any(String),
+        "@adobe/react-spectrum": expect.any(String),
+        "@adobe/uix-guest": expect.any(String),
+        "@react-spectrum/list": expect.any(String),
+        "@spectrum-icons/workflow": expect.any(String),
+        chalk: expect.any(String),
+        "core-js": expect.any(String),
+        "node-fetch": expect.any(String),
+        "node-html-parser": expect.any(String),
+        react: expect.any(String),
+        "react-dom": expect.any(String),
+        "react-error-boundary": expect.any(String),
+        "react-router-dom": expect.any(String),
+        "regenerator-runtime": expect.any(String),
+        "ajv": expect.any(String),
+        "js-yaml": expect.any(String),
       },
       {
-        '@babel/core': expect.any(String),
-        '@babel/plugin-transform-react-jsx': expect.any(String),
-        '@babel/polyfill': expect.any(String),
-        '@babel/preset-env': expect.any(String),
-        '@openwhisk/wskdebug': expect.any(String),
-        'jest': expect.any(String)
+        "@babel/core": expect.any(String),
+        "@babel/plugin-transform-react-jsx": expect.any(String),
+        "@babel/polyfill": expect.any(String),
+        "@babel/preset-env": expect.any(String),
+        "@openwhisk/wskdebug": expect.any(String),
+        jest: expect.any(String),
       }
-    )
-    assertEnvContent(prevDotEnv)
-    assertCodeContent(demoExtensionManifest)
-  })
-})
+    );
+    assertScripts(fs, {
+      "transform:yaml-to-json": expect.any(String),
+    });
+    assertEnvContent(prevDotEnv);
+    assertCodeContent(demoExtensionManifest);
+  });
+});

--- a/test/generator-add-web-assets-cf-admin.test.js
+++ b/test/generator-add-web-assets-cf-admin.test.js
@@ -28,6 +28,7 @@ const {
 const extFolder = "src/aem-cf-console-admin-1";
 const extConfigPath = path.join(extFolder, "ext.config.yaml");
 const webSrcFolder = path.join(extFolder, "web-src");
+const srcFolder = "src";
 
 const basicGeneratorOptions = {
   "web-src-folder": webSrcFolder,
@@ -61,6 +62,8 @@ function assertFiles(extensionManifest) {
   assert.file(`${webSrcFolder}/src/components/App.js`);
   assert.file(`${webSrcFolder}/src/components/ExtensionRegistration.js`);
   assert.file(`${webSrcFolder}/src/components/ExtensionRegistration.js`);
+  assert.file(`${srcFolder}/app-metadata.json`);
+
 
   // Assert generated modal files
   const actionBarButtons = extensionManifest.actionBarButtons || [];

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -33,3 +33,14 @@ global.assertDependencies = (fs, dependencies, devDependencies) => {
     devDependencies
   }))
 }
+
+/**
+ * Checks that package.json has all needed scripts specified.
+ *
+ * @param {object} scripts An object representing expected package.json scripts.
+ */
+global.assertScripts = (fs, scripts) => {
+  expect(JSON.parse(fs.readFileSync('package.json').toString())).toEqual(expect.objectContaining({
+    scripts
+  }))
+}


### PR DESCRIPTION
## Description

Adds hook to generate and verify metadata from app.config.yaml. Adds the generated metadata to extension registration.

## Related Issue

https://jira.corp.adobe.com/browse/SITES-17283

## Motivation and Context

We would like to generate metadata file from yaml configuration.
This will enable us to convey extension-related config to host, in cases where info from registry not available or feasible.
Generated metadata will be sent to host.

## How Has This Been Tested?

Tested manually by generating extension and local testing using ext param, the main use case.


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
